### PR TITLE
Updated coveralls configuration

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+coverage_clover: clover.xml
+json_path: coveralls-upload.json

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
     </testsuites>
 
     <filter>
-        <whitelist>
+        <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>


### PR DESCRIPTION
Added missing `.coveralls.yml` and processing uncovered files in PHPUnit configration


**Please enable coveralls for the repository**
It seems to be not enabled as badge in README.md shows unknown coverage.