### PR TITLE
Added space before colon in return type declaration

### DIFF
--- a/src/ZendAcl.php
+++ b/src/ZendAcl.php
@@ -27,7 +27,7 @@ class ZendAcl implements AuthorizationInterface
     /**
      * {@inheritDoc}
      */
-    public function isGranted(string $role, ServerRequestInterface $request): bool
+    public function isGranted(string $role, ServerRequestInterface $request) : bool
     {
         $routeResult = $request->getAttribute(RouteResult::class, false);
         if (false === $routeResult) {

--- a/src/ZendAclFactory.php
+++ b/src/ZendAclFactory.php
@@ -14,7 +14,7 @@ use Zend\Permissions\Acl\Exception\ExceptionInterface as AclExceptionInterface;
 
 class ZendAclFactory
 {
-    public function __invoke(ContainerInterface $container): AuthorizationInterface
+    public function __invoke(ContainerInterface $container) : AuthorizationInterface
     {
         $config = $container->get('config')['authorization'] ?? null;
         if (null === $config) {


### PR DESCRIPTION
Consistency fix, we always have space before and after the colon in return type declaration.