### PR TITLE
Allow usage of 1.0.0-dev branch of zend-expressive-authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.1.2 - 2017-12-13
+
+### Added
+
+- [#10](https://github.com/zendframework/zend-expressive-authorization-acl/pull/10)
+  adds support for the 1.0.0-dev branch of zend-expressive-authorization.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 0.1.1 - 2017-11-28
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "php": "^7.1",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-authorization": "^0.1 || ^0.2 || ^0.3 || ^1.0",
-        "zendframework/zend-expressive-router": "^2.1",
+        "zendframework/zend-expressive-authorization": "^0.1 || ^0.2 || ^0.3 || ^1.0.0-dev || ^1.0",
+        "zendframework/zend-expressive-router": "^2.1 || ^3.0.0-dev || ^3.0",
         "zendframework/zend-permissions-acl": "^2.6"
     },
     "require-dev": {
@@ -50,7 +50,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.0.x-dev"
         },
         "zf": {
             "config-provider": "Zend\\Expressive\\Authorization\\Acl\\ConfigProvider"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2732f5e4f0068a028e7fb87ea31c0822",
+    "content-hash": "f9c843623667d5bcab1b876a881c8e2b",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -2098,7 +2098,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zendframework/zend-expressive-authorization": 20,
+        "zendframework/zend-expressive-router": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
The 1.0.0-dev branch of zend-expressive-authorization prepares for incorporation of PSR-15 interfaces; however, the API it exposes for adapters does not change.