### PR TITLE
Updates package to allow alpha versions of dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,18 @@
         "slack": "https://zendframework-slack.herokuapp.com",
         "forum": "https://discourse.zendframework.com/c/questions/expressive"
     },
+    "minimum-stability": "alpha",
     "require": {
         "php": "^7.1",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-authorization": "^0.1 || ^0.2 || ^0.3 || ^1.0.0-dev || ^1.0",
-        "zendframework/zend-expressive-router": "^2.1 || ^3.0.0-dev || ^3.0",
+        "zendframework/zend-expressive-authorization": "^0.1 || ^0.2 || ^0.3 || ^1.0.0alpha2",
+        "zendframework/zend-expressive-router": "^2.1 || ^3.0.0alpha3",
         "zendframework/zend-permissions-acl": "^2.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0.2",
-        "zendframework/zend-coding-standard": "^1.0",
+        "zendframework/zend-coding-standard": "~1.0.0",
         "zendframework/zend-servicemanager": "^3.3"
     },
     "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ed53108058e089b0c53d3c128dd8738",
+    "content-hash": "3555ad87e82e1176613c73cd95e25254",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -55,59 +55,6 @@
                 "response"
             ],
             "time": "2017-02-09T16:10:21+00:00"
-        },
-        {
-            "name": "http-interop/http-middleware",
-            "version": "0.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/http-interop/http-middleware.git",
-                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/9a801fe60e70d5d608b61d56b2dcde29516c81b9",
-                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0",
-                "psr/http-message": "^1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Http\\ServerMiddleware\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP server-side middleware",
-            "keywords": [
-                "factory",
-                "http",
-                "middleware",
-                "psr",
-                "psr-17",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "abandoned": "http-interop/http-server-middleware",
-            "time": "2017-01-14T15:23:42+00:00"
         },
         {
             "name": "psr/container",
@@ -209,123 +156,136 @@
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
-            "name": "webimpress/composer-extra-dependency",
-            "version": "0.2.2",
+            "name": "psr/http-server-handler",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/composer-extra-dependency.git",
-                "reference": "31fa56391d30f03b1180c87610cbe22254780ad9"
+                "url": "https://github.com/php-fig/http-server-handler.git",
+                "reference": "439d92054dc06097f2406ec074a2627839955a02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/composer-extra-dependency/zipball/31fa56391d30f03b1180c87610cbe22254780ad9",
-                "reference": "31fa56391d30f03b1180c87610cbe22254780ad9",
+                "url": "https://api.github.com/repos/php-fig/http-server-handler/zipball/439d92054dc06097f2406ec074a2627839955a02",
+                "reference": "439d92054dc06097f2406ec074a2627839955a02",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1",
-                "php": "^5.6 || ^7.0"
+                "php": ">=7.0",
+                "psr/http-message": "^1.0"
             },
-            "require-dev": {
-                "composer/composer": "^1.5.2",
-                "mikey179/vfsstream": "^1.6.5",
-                "phpunit/phpunit": "^5.7.22 || ^6.4.1",
-                "zendframework/zend-coding-standard": "~1.0.0"
-            },
-            "type": "composer-plugin",
+            "type": "library",
             "extra": {
-                "class": "Webimpress\\ComposerExtraDependency\\Plugin"
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
             },
             "autoload": {
                 "psr-4": {
-                    "Webimpress\\ComposerExtraDependency\\": "src/"
+                    "Psr\\Http\\Server\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-2-Clause"
+                "MIT"
             ],
-            "description": "Composer plugin to require extra dependencies",
-            "homepage": "https://github.com/webimpress/composer-extra-dependency",
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side request handler",
             "keywords": [
-                "composer",
-                "dependency",
-                "webimpress"
+                "handler",
+                "http",
+                "http-interop",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response",
+                "server"
             ],
-            "time": "2017-10-17T17:15:14+00:00"
+            "time": "2018-01-22T17:04:15+00:00"
         },
         {
-            "name": "webimpress/http-middleware-compatibility",
-            "version": "0.1.4",
+            "name": "psr/http-server-middleware",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/http-middleware-compatibility.git",
-                "reference": "8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717"
+                "url": "https://github.com/php-fig/http-server-middleware.git",
+                "reference": "ea17eb1fb2c8df6db919cc578451a8013c6a0ae5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717",
-                "reference": "8ed1c2c7523dce0035b98bc4f3a73ca9cd1d3717",
+                "url": "https://api.github.com/repos/php-fig/http-server-middleware/zipball/ea17eb1fb2c8df6db919cc578451a8013c6a0ae5",
+                "reference": "ea17eb1fb2c8df6db919cc578451a8013c6a0ae5",
                 "shasum": ""
             },
             "require": {
-                "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
-                "php": "^5.6 || ^7.0",
-                "webimpress/composer-extra-dependency": "^0.2.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.23 || ^6.4.3"
+                "php": ">=7.0",
+                "psr/http-message": "^1.0",
+                "psr/http-server-handler": "^1.0"
             },
             "type": "library",
             "extra": {
-                "dependency": [
-                    "http-interop/http-middleware"
-                ]
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
             },
             "autoload": {
-                "files": [
-                    "autoload/http-middleware.php"
-                ]
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-2-Clause"
+                "MIT"
             ],
-            "description": "Compatibility library for Draft PSR-15 HTTP Middleware",
-            "homepage": "https://github.com/webimpress/http-middleware-compatibility",
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side middleware",
             "keywords": [
+                "http",
+                "http-interop",
                 "middleware",
+                "psr",
                 "psr-15",
-                "webimpress"
+                "psr-7",
+                "request",
+                "response"
             ],
-            "abandoned": "psr/http-server-middleware",
-            "time": "2017-10-17T17:31:10+00:00"
+            "time": "2018-01-22T17:08:31+00:00"
         },
         {
             "name": "zendframework/zend-expressive-authentication",
-            "version": "0.2.0",
+            "version": "1.0.0alpha4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-authentication.git",
-                "reference": "d9971483056cfc55e6193a709f6c1d934d97d7f8"
+                "reference": "290e4d67fb9b5728755e3bf6082242578ceb51ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-authentication/zipball/d9971483056cfc55e6193a709f6c1d934d97d7f8",
-                "reference": "d9971483056cfc55e6193a709f6c1d934d97d7f8",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-authentication/zipball/290e4d67fb9b5728755e3bf6082242578ceb51ad",
+                "reference": "290e4d67fb9b5728755e3bf6082242578ceb51ad",
                 "shasum": ""
             },
             "require": {
-                "http-interop/http-middleware": "^0.4.1",
                 "php": "^7.1",
                 "psr/container": "^1.0",
-                "psr/http-message": "^1.0.1"
+                "psr/http-message": "^1.0.1",
+                "psr/http-server-middleware": "^1.0"
             },
             "conflict": {
                 "container-interop/container-interop": "<1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.3",
+                "phpunit/phpunit": "^7.0.2",
                 "roave/security-advisories": "dev-master",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
@@ -338,7 +298,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "0.2.x-dev",
+                    "dev-release-1.0.0": "1.0.x-dev"
+                },
+                "zf": {
+                    "config-provider": "Zend\\Expressive\\Authentication\\ConfigProvider"
                 }
             },
             "autoload": {
@@ -356,51 +320,51 @@
                 "ZendFramework",
                 "http",
                 "middleware",
+                "psr-15",
                 "psr-7",
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2017-11-27T16:59:48+00:00"
+            "time": "2018-02-27T14:48:50+00:00"
         },
         {
             "name": "zendframework/zend-expressive-authorization",
-            "version": "0.3.0",
+            "version": "1.0.0alpha2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-authorization.git",
-                "reference": "1e891598efe5b4eeb29c74c38f7dfea7fae12643"
+                "reference": "734bfd547fed1b4cb0d3f3f35a68aabf9552087a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-authorization/zipball/1e891598efe5b4eeb29c74c38f7dfea7fae12643",
-                "reference": "1e891598efe5b4eeb29c74c38f7dfea7fae12643",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-authorization/zipball/734bfd547fed1b4cb0d3f3f35a68aabf9552087a",
+                "reference": "734bfd547fed1b4cb0d3f3f35a68aabf9552087a",
                 "shasum": ""
             },
             "require": {
-                "http-interop/http-middleware": "^0.4.1",
                 "php": "^7.1",
                 "psr/container": "^1.0",
                 "psr/http-message": "^1.0.1",
-                "webimpress/http-middleware-compatibility": "^0.1.1",
-                "zendframework/zend-expressive-authentication": "^0.2 || ^1.0",
-                "zendframework/zend-expressive-router": "^2.2"
+                "psr/http-server-middleware": "^1.0",
+                "zendframework/zend-expressive-authentication": "^1.0.0alpha3"
             },
             "conflict": {
                 "container-interop/container-interop": "<1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0.8",
+                "phpunit/phpunit": "^7.0.2",
                 "roave/security-advisories": "dev-master",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
-                "zendframework/zend-expressive-authorization-acl": "^0.1 || ^1.0; provides a zend-permissions-acl-backed adapter",
-                "zendframework/zend-expressive-authorization-rbac": "^0.1 || ^1.0; provides a zend-permissions-rbac-backed adapter"
+                "zendframework/zend-expressive-authorization-acl": "^1.0; provides a zend-permissions-acl-backed adapter",
+                "zendframework/zend-expressive-authorization-rbac": "^1.0; provides a zend-permissions-rbac-backed adapter"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "0.3.x-dev",
+                    "dev-release-1.0.0": "1.0.x-dev"
                 },
                 "zf": {
                     "config-provider": "Zend\\Expressive\\Authorization\\ConfigProvider"
@@ -416,50 +380,57 @@
                 "BSD-3-Clause"
             ],
             "description": "Authorization middleware for Expressive and PSR-7 applications",
-            "homepage": "https://docs.zendframework.com/zend-expressive-authorization/",
             "keywords": [
+                "ZendFramework",
                 "authorization",
                 "middleware",
+                "psr-15",
                 "psr-7",
-                "zend-expressive"
+                "zend-expressive",
+                "zf"
             ],
-            "time": "2017-11-28T20:19:59+00:00"
+            "time": "2018-02-27T15:13:28+00:00"
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "2.2.0",
+            "version": "3.0.0alpha3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "f6eac53d39cdbf7b6db11b3e6bb3565896633de4"
+                "reference": "737f79bffa8900388367d02e66dc0d0bcdba1eed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/f6eac53d39cdbf7b6db11b3e6bb3565896633de4",
-                "reference": "f6eac53d39cdbf7b6db11b3e6bb3565896633de4",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/737f79bffa8900388367d02e66dc0d0bcdba1eed",
+                "reference": "737f79bffa8900388367d02e66dc0d0bcdba1eed",
                 "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
-                "php": "^5.6 || ^7.0",
+                "php": "^7.1",
+                "psr/container": "^1.0",
                 "psr/http-message": "^1.0.1",
-                "webimpress/http-middleware-compatibility": "^0.1.1"
+                "psr/http-server-middleware": "^1.0"
             },
             "require-dev": {
-                "malukenho/docheader": "^0.1.5",
-                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "malukenho/docheader": "^0.1.6",
+                "phpunit/phpunit": "^6.5.5",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
-                "zendframework/zend-expressive-aurarouter": "^1.0 to use the Aura.Router routing adapter",
-                "zendframework/zend-expressive-fastroute": "^1.2 to use the FastRoute routing adapter",
-                "zendframework/zend-expressive-zendrouter": "^1.2 to use the zend-router routing adapter"
+                "zendframework/zend-expressive-aurarouter": "^3.0 to use the Aura.Router routing adapter",
+                "zendframework/zend-expressive-fastroute": "^3.0 to use the FastRoute routing adapter",
+                "zendframework/zend-expressive-zendrouter": "^3.0 to use the zend-router routing adapter"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev",
-                    "dev-develop": "2.3-dev"
+                    "dev-master": "2.3.x-dev",
+                    "dev-develop": "2.4.x-dev",
+                    "dev-release-3.0.0": "3.0.x-dev"
+                },
+                "zf": {
+                    "config-provider": "Zend\\Expressive\\Router\\ConfigProvider"
                 }
             },
             "autoload": {
@@ -473,13 +444,16 @@
             ],
             "description": "Router subcomponent for Expressive",
             "keywords": [
+                "ZendFramework",
                 "expressive",
                 "http",
                 "middleware",
                 "psr",
-                "psr-7"
+                "psr-7",
+                "zend-expressive",
+                "zf"
             ],
-            "time": "2017-10-09T18:44:11+00:00"
+            "time": "2018-02-21T18:39:37+00:00"
         },
         {
             "name": "zendframework/zend-permissions-acl",
@@ -2239,10 +2213,10 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "alpha",
     "stability-flags": {
-        "zendframework/zend-expressive-authorization": 20,
-        "zendframework/zend-expressive-router": 20
+        "zendframework/zend-expressive-authorization": 15,
+        "zendframework/zend-expressive-router": 15
     },
     "prefer-stable": false,
     "prefer-lowest": false,


### PR DESCRIPTION
Previously, we pinned to `-dev` releases; we now pin to `alpha{Y}` releases, and remove the stable release associated with the alpha (as stable will be installed when available).